### PR TITLE
Remove unused terms check from registration logic

### DIFF
--- a/lib/pages/auth/view/register_page.dart
+++ b/lib/pages/auth/view/register_page.dart
@@ -26,7 +26,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
   late TextEditingController passwordController;
   late TextEditingController repeatPasswordController;
   bool _isLoading = false;
-  bool _acceptTerms = false;
 
   @override
   void initState() {
@@ -38,15 +37,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
   Future<void> _handleSignUp() async {
     if (!_formKey.currentState!.validate()) return;
-
-    if (!_acceptTerms) {
-      SnackbarUtils.showSnackBar(
-        context,
-        message: 'Please accept the Terms and Conditions',
-        isError: true,
-      );
-      return;
-    }
 
     setState(() {
       _isLoading = true;
@@ -79,12 +69,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
     }
   }
 
-  void _onTermsChanged(bool? value) {
-    setState(() {
-      _acceptTerms = value ?? false;
-    });
-  }
-
   @override
   void dispose() {
     emailController.dispose();
@@ -107,8 +91,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
           passwordController: passwordController,
           repeatPasswordController: repeatPasswordController,
           isLoading: _isLoading,
-          acceptTerms: _acceptTerms,
-          onTermsChanged: _onTermsChanged,
           onSignUp: _handleSignUp,
           onSwitchToLogin: widget.onTap,
         ),
@@ -138,8 +120,6 @@ class _RegisterForm extends StatelessWidget {
     required this.passwordController,
     required this.repeatPasswordController,
     required this.isLoading,
-    required this.acceptTerms,
-    required this.onTermsChanged,
     required this.onSignUp,
     required this.onSwitchToLogin,
   });
@@ -149,8 +129,6 @@ class _RegisterForm extends StatelessWidget {
   final TextEditingController passwordController;
   final TextEditingController repeatPasswordController;
   final bool isLoading;
-  final bool acceptTerms;
-  final ValueChanged<bool?> onTermsChanged;
   final VoidCallback onSignUp;
   final VoidCallback onSwitchToLogin;
 


### PR DESCRIPTION
This pull request includes changes to the `lib/pages/auth/view/register_page.dart` file, specifically to the `RegisterScreenState` and `RegisterForm` classes. The main focus of these changes is to remove the acceptance of terms and conditions from the registration process.

Changes to `RegisterScreenState` class:

* Removed `_acceptTerms` boolean variable initialization.
* Removed the check for `_acceptTerms` in the `_handleSignUp` method.
* Removed the `_onTermsChanged` method.
* Updated the widget build method to remove references to `_acceptTerms` and `_onTermsChanged`.

Changes to `RegisterForm` class:

* Removed `acceptTerms` and `onTermsChanged` parameters from the constructor.
* Removed the `acceptTerms` and `onTermsChanged` fields.